### PR TITLE
Add floating client metadata

### DIFF
--- a/lexfloatclient.go
+++ b/lexfloatclient.go
@@ -286,8 +286,7 @@ func GetFloatingClientMeterAttributeUses(name string, uses *uint) int {
     PARAMETERS:
     * key - key of the metadata field whose value you want to retrieve
     * value - pointer to a buffer that receives the value of the string
-    * length - size of the buffer pointed to by the value parameter
-
+    
     RETURN CODES: LF_OK, LF_E_PRODUCT_ID, LF_E_NO_LICENSE, LF_E_BUFFER_SIZE,
     LF_E_METADATA_KEY_NOT_FOUND
 */

--- a/lexfloatclient.go
+++ b/lexfloatclient.go
@@ -277,6 +277,29 @@ func GetFloatingClientMeterAttributeUses(name string, uses *uint) int {
 	freeCString(cName)
 	return int(status)
 }
+
+/*
+    FUNCTION: GetFloatingClientMetadata()
+
+    PURPOSE: Gets the value of the floating client metadata.
+
+    PARAMETERS:
+    * key - key of the metadata field whose value you want to retrieve
+    * value - pointer to a buffer that receives the value of the string
+    * length - size of the buffer pointed to by the value parameter
+
+    RETURN CODES: LF_OK, LF_E_PRODUCT_ID, LF_E_NO_LICENSE, LF_E_BUFFER_SIZE,
+    LF_E_METADATA_KEY_NOT_FOUND
+*/
+func GetFloatingClientMetadata(key string, value *string) int {
+	cKey := goToCString(key)
+	var cValue = getCArray()
+	status := C.GetFloatingClientMetadata(cKey, &cValue[0], maxCArrayLength)
+	*value = ctoGoString(&cValue[0])
+	freeCString(cKey)
+	return int(status)
+
+}
 /*
     FUNCTION: RequestFloatingLicense()
 

--- a/lexfloatclient/LexFloatClient.h
+++ b/lexfloatclient/LexFloatClient.h
@@ -234,6 +234,21 @@ LEXFLOATCLIENT_API int LF_CC GetHostLicenseExpiryDate(uint32_t *expiryDate);
 LEXFLOATCLIENT_API int LF_CC GetFloatingClientMeterAttributeUses(CSTRTYPE name, uint32_t *uses);
 
 /*
+    FUNCTION: GetFloatingClientMetadata()
+
+    PURPOSE: Gets the value of the floating client metadata.
+
+    PARAMETERS:
+    * key - key of the metadata field whose value you want to retrieve
+    * value - pointer to a buffer that receives the value of the string
+    * length - size of the buffer pointed to by the value parameter
+
+    RETURN CODES: LF_OK, LF_E_PRODUCT_ID, LF_E_NO_LICENSE, LF_E_BUFFER_SIZE,
+    LF_E_METADATA_KEY_NOT_FOUND
+*/
+LEXFLOATCLIENT_API int LF_CC GetFloatingClientMetadata(CSTRTYPE key, STRTYPE value, uint32_t length);
+
+/*
     FUNCTION: RequestFloatingLicense()
 
     PURPOSE: Sends the request to lease the license from the LexFloatServer.


### PR DESCRIPTION
The `GetFloatingClientMetadata` function is implemented to get the value of a specific metadata field using the provided key. The function takes the key as a parameter and returns the value of the string associated with that key. 