### PR TITLE
feat: add request offline floating license

### DIFF
--- a/lexfloatclient.go
+++ b/lexfloatclient.go
@@ -323,6 +323,22 @@ func HasFloatingLicense() int {
 }
 
 /*
+    FUNCTION: RequestOfflineFloatingLicense()
+
+    PURPOSE: Sends the request to lease the license from the LexFloatServer for offline usage.
+
+    RETURN CODES: LF_OK, LF_FAIL, LF_E_PRODUCT_ID, LF_E_LICENSE_EXISTS, LF_E_HOST_URL,
+    LF_E_LICENSE_LIMIT_REACHED, LF_E_INET, LF_E_TIME, LF_E_CLIENT, LF_E_IP, LF_E_SERVER,
+    LF_E_SERVER_LICENSE_NOT_ACTIVATED, LF_E_SERVER_TIME_MODIFIED, LF_E_SERVER_LICENSE_SUSPENDED,
+    LF_E_SERVER_LICENSE_GRACE_PERIOD_OVER, LF_E_SERVER_LICENSE_EXPIRED, LF_E_WMIC, LF_E_SYSTEM_PERMISSION
+*/
+func RequestOfflineFloatingLicense(leaseDuration uint) int {
+    cLeaseDuration := (C.uint)(leaseDuration)
+    status := C.RequestOfflineFloatingLicense(cLeaseDuration)
+    return int(status)
+};
+
+/*
     FUNCTION: IncrementFloatingClientMeterAttributeUses()
 
     PURPOSE: Increments the meter attribute uses of the floating client.

--- a/lexfloatclient.go
+++ b/lexfloatclient.go
@@ -327,6 +327,11 @@ func HasFloatingLicense() int {
 
     PURPOSE: Sends the request to lease the license from the LexFloatServer for offline usage.
 
+    The maximum value of lease duration is configured in the config.yml of LexFloatServer 
+
+    PARAMETERS:
+    * leaseDuration - value of the lease duration.
+
     RETURN CODES: LF_OK, LF_FAIL, LF_E_PRODUCT_ID, LF_E_LICENSE_EXISTS, LF_E_HOST_URL,
     LF_E_LICENSE_LIMIT_REACHED, LF_E_INET, LF_E_TIME, LF_E_CLIENT, LF_E_IP, LF_E_SERVER,
     LF_E_SERVER_LICENSE_NOT_ACTIVATED, LF_E_SERVER_TIME_MODIFIED, LF_E_SERVER_LICENSE_SUSPENDED,

--- a/lexfloatclient/LexFloatClient.h
+++ b/lexfloatclient/LexFloatClient.h
@@ -270,6 +270,18 @@ LEXFLOATCLIENT_API int LF_CC DropFloatingLicense();
 LEXFLOATCLIENT_API int LF_CC HasFloatingLicense();
 
 /*
+    FUNCTION: RequestOfflineFloatingLicense()
+
+    PURPOSE: Sends the request to lease the license from the LexFloatServer for offline usage.
+
+    RETURN CODES: LF_OK, LF_FAIL, LF_E_PRODUCT_ID, LF_E_LICENSE_EXISTS, LF_E_HOST_URL,
+    LF_E_LICENSE_LIMIT_REACHED, LF_E_INET, LF_E_TIME, LF_E_CLIENT, LF_E_IP, LF_E_SERVER,
+    LF_E_SERVER_LICENSE_NOT_ACTIVATED, LF_E_SERVER_TIME_MODIFIED, LF_E_SERVER_LICENSE_SUSPENDED,
+    LF_E_SERVER_LICENSE_GRACE_PERIOD_OVER, LF_E_SERVER_LICENSE_EXPIRED, LF_E_WMIC, LF_E_SYSTEM_PERMISSION
+*/
+LEXFLOATCLIENT_API int LF_CC RequestOfflineFloatingLicense(uint32_t leaseDuration);
+
+/*
     FUNCTION: IncrementFloatingClientMeterAttributeUses()
 
     PURPOSE: Increments the meter attribute uses of the floating client.

--- a/lexfloatclient/LexFloatClient.h
+++ b/lexfloatclient/LexFloatClient.h
@@ -273,6 +273,11 @@ LEXFLOATCLIENT_API int LF_CC HasFloatingLicense();
     FUNCTION: RequestOfflineFloatingLicense()
 
     PURPOSE: Sends the request to lease the license from the LexFloatServer for offline usage.
+    
+    The maximum value of lease duration is configured in the config.yml of LexFloatServer 
+
+    PARAMETERS:
+    * leaseDuration - value of the lease duration.
 
     RETURN CODES: LF_OK, LF_FAIL, LF_E_PRODUCT_ID, LF_E_LICENSE_EXISTS, LF_E_HOST_URL,
     LF_E_LICENSE_LIMIT_REACHED, LF_E_INET, LF_E_TIME, LF_E_CLIENT, LF_E_IP, LF_E_SERVER,


### PR DESCRIPTION
The `RequestOfflineFloatingLicense` function sends a request to lease the license for offline usage. The function takes a `leaseDuration` parameter, which specifies the duration of the lease in seconds. The function returns various status codes indicating the success or failure of the request. This feature allows users to use the license offline when an internet connection is not available.